### PR TITLE
Refactor Markdown documentation structure

### DIFF
--- a/CODABENCH_README.md
+++ b/CODABENCH_README.md
@@ -1,0 +1,79 @@
+# SEE Challenge 2026: Event-Guided Low-Level Imaging
+
+<p align="center">
+  <img src="./images/SEE-logo.jpg" alt="SEE Challenge 2026 logo" width="260">
+</p>
+Welcome to the **SEE Challenge 2026**, associated with **EBMV @ ECCV 2026: Event-Based Multimodal Vision: Imaging, Perception, and Understanding**.
+
+This challenge focuses on **event-guided brightness adjustment under broad lighting conditions**. Participants receive RGB frames captured under challenging illumination together with corresponding event streams or event representations, and produce brightness-adjusted RGB images that are well exposed, structurally faithful, and visually clear.
+
+## Task
+
+Given:
+
+- an RGB image captured under challenging illumination;
+- the corresponding event stream or event representation;
+- an optional brightness prompt or metadata if provided;
+
+participants should output a **brightness-adjusted RGB image**.
+
+The output should preserve scene structure, recover useful details, maintain natural color appearance, and avoid unrealistic hallucination.
+
+## Dataset
+
+The challenge uses **SEE-600K**, a large-scale RGB-event dataset containing:
+
+- 610,126 images with corresponding event data;
+- 202 real-world scenarios;
+- low-light, normal-light, and high-light conditions;
+- multiple lighting groups per scene;
+- broad illumination variations for event-guided image enhancement.
+
+Dataset: <https://huggingface.co/datasets/yunfanlu/SEE-600K>
+
+## Evaluation
+
+Official evaluation is conducted on the test set.
+
+| Metric | Meaning | Ranking |
+| --- | --- | --- |
+| PSNR | Pixel-level reconstruction accuracy | Primary, higher is better |
+| SSIM | Structural similarity | Secondary, higher is better |
+| LPIPS | Perceptual distance | Secondary, lower is better |
+
+## Timeline
+
+| Date | Event |
+| --- | --- |
+| May 10, 2026 | Challenge website opens |
+| May 25, 2026 | Validation server online |
+| June 25, 2026 | Test data released and test server online |
+| July 3, 2026 | Test submission deadline |
+| July 10, 2026 | Results announcement, tentative |
+
+## Visual Overview
+
+| Problem Definition | Dataset Samples |
+| --- | --- |
+| <img src="./images/2-Problem-Define.jpg" alt="SEE challenge task definition with challenging input, event guidance, and restored output"> | <img src="./images/0-Dataset-Sample.jpg" alt="SEE-600K dataset samples under low, normal, and high lighting conditions"> |
+| Input RGB under challenging illumination + event representation -> brightness-adjusted RGB output. | Examples cover low-light, normal-light, high-light, mixed illumination, and event views. |
+
+| Scenario Coverage | Baseline Visualization |
+| --- | --- |
+| <img src="./images/1-MoreExamples-WordCloud.jpg" alt="SEE-600K scene examples and scenario word cloud"> | <img src="./images/3-BaseLine-Release.jpg" alt="SEE baseline visualization results produced by the released code"> |
+| 202 real-world scenarios with broad scene categories and multiple lighting groups. | SEE-Net uses RGB frames, event data, and a brightness prompt for controllable output exposure. |
+
+## Get Started
+
+1. Visit the GitHub repository for code and documentation: <https://github.com/yunfanLu/SEE>.
+2. Download SEE-600K from Hugging Face: <https://huggingface.co/datasets/yunfanlu/SEE-600K>.
+3. Follow the repository tutorial to set up the environment and run the baseline.
+4. Follow the repository CodaBench submission guide when preparing your submission package.
+
+## Links
+
+- **GitHub Repository**: <https://github.com/yunfanLu/SEE>
+- **Workshop Website**: <https://eventbasemultimodalvision.github.io>
+- **Competition Page**: <https://www.codabench.org/competitions/16195/>
+- **Competition Forum**: <https://www.codabench.org/forums/15944/>
+- **Competition Report**: <https://arxiv.org/abs/2502.21120>

--- a/CODABENCH_README_ZH.md
+++ b/CODABENCH_README_ZH.md
@@ -1,0 +1,79 @@
+# SEE Challenge 2026：事件引导的低层视觉成像
+
+<p align="center">
+  <img src="./images/SEE-logo.jpg" alt="SEE Challenge 2026 logo" width="260">
+</p>
+欢迎参加 **SEE Challenge 2026**。本挑战隶属于 **EBMV @ ECCV 2026：Event-Based Multimodal Vision: Imaging, Perception, and Understanding**。
+
+本挑战关注**宽光照条件下的事件引导亮度调整**。参赛者将获得在复杂光照下采集的 RGB 图像及其对应的事件流或事件表示，并生成曝光良好、结构忠实且视觉清晰的亮度调整后 RGB 图像。
+
+## 任务
+
+给定：
+
+- 一张在复杂光照下采集的 RGB 图像；
+- 对应的事件流或事件表示；
+- 如提供，则还包括可选的亮度提示或元数据；
+
+参赛者应输出一张**亮度调整后的 RGB 图像**。
+
+输出应保持场景结构，恢复有用细节，维持自然色彩表现，并避免不真实的幻觉内容。
+
+## 数据集
+
+本挑战使用 **SEE-600K**，这是一个大规模 RGB-事件数据集，包含：
+
+- 610,126 张图像及对应事件数据；
+- 202 个真实世界场景；
+- 低光、正常光和高光条件；
+- 每个场景包含多个光照组；
+- 面向事件引导图像增强的宽范围光照变化。
+
+数据集：<https://huggingface.co/datasets/yunfanlu/SEE-600K>
+
+## 评测
+
+官方评测将在测试集上进行。
+
+| 指标 | 含义 | 排名依据 |
+| --- | --- | --- |
+| PSNR | 像素级重建精度 | 主要指标，越高越好 |
+| SSIM | 结构相似性 | 次要指标，越高越好 |
+| LPIPS | 感知距离 | 次要指标，越低越好 |
+
+## 时间安排
+
+| 日期 | 事件 |
+| --- | --- |
+| 2026 年 5 月 10 日 | 挑战网站开放 |
+| 2026 年 5 月 25 日 | 验证服务器上线 |
+| 2026 年 6 月 25 日 | 测试数据发布，测试服务器上线 |
+| 2026 年 7 月 3 日 | 测试提交截止 |
+| 2026 年 7 月 10 日 | 结果公布，暂定 |
+
+## 视觉概览
+
+| 问题定义 | 数据集样例 |
+| --- | --- |
+| <img src="./images/2-Problem-Define.jpg" alt="SEE challenge task definition with challenging input, event guidance, and restored output"> | <img src="./images/0-Dataset-Sample.jpg" alt="SEE-600K dataset samples under low, normal, and high lighting conditions"> |
+| 复杂光照下的输入 RGB + 事件表示 -> 亮度调整后的 RGB 输出。 | 示例覆盖低光、正常光、高光、混合光照和事件视图。 |
+
+| 场景覆盖 | 基线可视化 |
+| --- | --- |
+| <img src="./images/1-MoreExamples-WordCloud.jpg" alt="SEE-600K scene examples and scenario word cloud"> | <img src="./images/3-BaseLine-Release.jpg" alt="SEE baseline visualization results produced by the released code"> |
+| 202 个真实世界场景，覆盖广泛场景类别和多个光照组。 | SEE-Net 使用 RGB 图像、事件数据和亮度提示实现可控输出曝光。 |
+
+## 快速开始
+
+1. 访问 GitHub 仓库获取代码和文档：<https://github.com/yunfanLu/SEE>。
+2. 从 Hugging Face 下载 SEE-600K：<https://huggingface.co/datasets/yunfanlu/SEE-600K>。
+3. 按照仓库教程配置环境并运行基线。
+4. 准备提交包时，请按照仓库中的 CodaBench 提交指南操作。
+
+## 链接
+
+- **GitHub Repository**: <https://github.com/yunfanLu/SEE>
+- **Workshop Website**: <https://eventbasemultimodalvision.github.io>
+- **Competition Page**: <https://www.codabench.org/competitions/16195/>
+- **Competition Forum**: <https://www.codabench.org/forums/15944/>
+- **Competition Report**: <https://arxiv.org/abs/2502.21120>

--- a/README.md
+++ b/README.md
@@ -1,233 +1,59 @@
-# SEE: See Everything Every Time 🌟👀
-Welcome to the **SEE** project repository! We introduce a new framework for enhancing images across a broad light range using event-based cameras. Our approach adjusts brightness dynamically to enhance image quality in both low and high light conditions. This repository contains the data and code for the **SEE-600K dataset** and **SEE-Net framework**.
+# SEE: See Everything Every Time
 
-## 🎯 Overview
-In this project, we explore how to use event-based cameras, with their high dynamic range (HDR), to handle images under various lighting conditions. We propose the **SEE-600K dataset**—a large-scale dataset capturing images under a range of lighting conditions—and a novel framework, **SEE-Net**, that can adjust brightness smoothly and effectively using events.
+**SEE** is a framework for adaptive brightness adjustment across broad lighting conditions using RGB frames and event-camera data. This repository provides the code for **SEE-Net** and resources for the **SEE-600K** dataset.
 
----
+SEE-Net uses event guidance to enhance images captured under low light, over-exposure, mixed illumination, and high-contrast scenes while preserving scene structure and natural appearance.
 
-## 🔥 SEE Challenge 2026
+## Key Features
 
-<p align="center">
-  <img src="./images/SEE-logo.jpg" alt="SEE Challenge 2026 logo" width="260">
-</p>
+- **Event-guided brightness adjustment**: uses RGB frames together with event data for broad-light-range image enhancement.
+- **Continuous exposure control**: supports pixel-level brightness adjustment through an exposure prompt.
+- **Compact baseline**: SEE-Net has approximately **1.9M parameters**.
+- **Large-scale dataset support**: built around SEE-600K, which contains **610,126 images with corresponding event data** across **202 real-world scenarios**.
 
-We are organizing the **SEE Challenge 2026: Event-Guided Low-Level Imaging**, associated with **EBMV @ ECCV 2026**: **Event-Based Multimodal Vision: Imaging, Perception, and Understanding**.
+## Dataset Download
 
-This challenge focuses on **event-guided brightness adjustment under broad lighting conditions**. Participants are asked to use RGB frames and event streams to restore well-exposed, structurally faithful, and visually clear images from challenging illumination scenes, including low light, over-exposure, mixed illumination, and high-contrast conditions.
+The datasets supporting this project are publicly available:
 
-The challenge is based on **SEE-600K**, a large-scale RGB-event dataset introduced in our paper.
-
-### Task
-
-Given:
-
-- an RGB image captured under challenging illumination,
-- the corresponding event stream or event representation,
-- optional brightness prompt or metadata if provided,
-
-participants should output a **brightness-adjusted RGB image**.
-
-The output should preserve scene structure, recover useful details, maintain natural color appearance, and avoid unrealistic hallucination.
-
-### Dataset
-
-The challenge uses **SEE-600K**, which contains:
-
-- 610,126 images with corresponding event data,
-- 202 real-world scenarios,
-- low-light, normal-light, and high-light conditions,
-- multiple lighting groups per scene,
-- broad illumination variations for event-guided image enhancement.
-
-Dataset link: [https://huggingface.co/datasets/yunfanlu/SEE-600K](https://huggingface.co/datasets/yunfanlu/SEE-600K)
-
-### Evaluation
-
-The official evaluation will be conducted on the test set.
-
-| Metric | Meaning | Ranking |
-| --- | --- | --- |
-| PSNR | Pixel-level reconstruction accuracy | Primary, higher is better |
-| SSIM | Structural similarity | Secondary, higher is better |
-| LPIPS | Perceptual distance | Secondary, lower is better |
-
-### Timeline
-
-| Date | Event |
-| --- | --- |
-| May 10, 2026 | Challenge website opens |
-| May 25, 2026 | Validation server online |
-| June 25, 2026 | Test data released and test server online |
-| July 3, 2026 | Test submission deadline |
-| July 10, 2026 | Results announcement, tentative |
-
-### Challenge Visuals
-
-| Problem Definition | Dataset Samples |
-| --- | --- |
-| <img src="./images/2-Problem-Define.jpg" alt="SEE challenge task definition with challenging input, event guidance, and restored output"> | <img src="./images/0-Dataset-Sample.jpg" alt="SEE-600K dataset samples under low, normal, and high lighting conditions"> |
-| Input RGB under challenging illumination + event representation -> brightness-adjusted RGB output. | Examples cover low-light, normal-light, high-light, mixed illumination, and event views. |
-
-| Scenario Coverage | Baseline Visualization |
-| --- | --- |
-| <img src="./images/1-MoreExamples-WordCloud.jpg" alt="SEE-600K scene examples and scenario word cloud"> | <img src="./images/3-BaseLine-Release.jpg" alt="SEE baseline visualization results produced by the released code"> |
-| 202 real-world scenarios with broad scene categories and multiple lighting groups. | SEE-Net uses RGB frames, event data, and a brightness prompt for controllable output exposure. |
-
-### Links
-
-- **Workshop Website**: [https://eventbasemultimodalvision.github.io](https://eventbasemultimodalvision.github.io)
-- **Dataset**: [https://huggingface.co/datasets/yunfanlu/SEE-600K](https://huggingface.co/datasets/yunfanlu/SEE-600K)
-- **Baseline Code**: [https://github.com/yunfanLu/SEE](https://github.com/yunfanLu/SEE)
-- **Competition Page**: [https://www.codabench.org/competitions/16195/](https://www.codabench.org/competitions/16195/#/pages-tab)
-
----
-
-## 📚 Paper Summary
-In our research paper, we:
-- Collect the **SEE-600K dataset** consisting of 610,126 images and corresponding events under 202 scenarios with a range of lighting conditions.
-- Introduce the **SEE-Net framework**, which effectively adjusts image brightness using event-based data.
-- Demonstrate that our framework performs well across a broad range of lighting, from very low to very high light levels.
-- Show the flexibility of our method through pixel-level brightness adjustments, which can be useful for various post-processing applications.
-
----
-
-## 📂 Data Availability
-The datasets supporting the results of this article are publicly available:
-- **SEE-600K Dataset**:
+- **SEE-600K Dataset**
   - [OneDrive](https://hkustgz-my.sharepoint.com/:f:/g/personal/ylu066_connect_hkust-gz_edu_cn/EkNi59p2uHJFjxyeQraiVhgBSs1GnxK4DyCUP-uZhEspCA?e=ZpwOvY)
-  - [Huggingface](https://huggingface.co/datasets/yunfanlu/SEE-600K)
+  - [Hugging Face](https://huggingface.co/datasets/yunfanlu/SEE-600K)
 - **SDE Dataset**: [SDE Dataset GitHub](https://github.com/EthanLiang99/EvLight)
 
----
+## Pretrained Models
 
-## 🛠️ Code & Framework
+Pretrained checkpoints, evaluation logs, and experiment files for the released baselines are available on Google Drive:
 
-### 🎥 SEE-Net Framework
+<https://drive.google.com/drive/folders/1SWR9YVIrqFEkGGKrv3wSC5RqmMIEYjV2?usp=sharing>
 
-The **SEE-Net** framework is designed to adjust the brightness of images under a variety of lighting conditions. It utilizes event-based data to enhance low-light and high-light images and improve their overall quality.
+The folder is organized by method and includes checkpoints for `EIFT_AAAI_SEE`, `eSl_SEE`, `EvLight`, and `SEENet_SEE`, along with related logs and `TEST_RESULTS.md`.
 
-Key Features:
-- **Brightness Adjustment** 🌈: Our framework allows for pixel-level brightness adjustment based on the events captured by the camera.
-- **Compact & Efficient** ⚡: SEE-Net is designed with efficiency in mind, with only 1.9 million parameters, making it suitable for real-time applications.
+## Documentation
 
-### Pretrain Model
+- [Tutorial](docs/TUTORIAL.md): environment setup, dataset preparation, training, evaluation, inference, and FAQ.
+- [CodaBench Submission Guide](docs/CODABENCH_SUBMISSION_GUIDE.md): step-by-step instructions for packaging and submitting results to CodaBench.
+- [CodaBench Page Description](CODABENCH_README.md): concise standalone text for the SEE Challenge CodaBench page.
+- [Test Results](docs/TEST_RESULTS.md): baseline results on the SEE dataset.
+- [Mini-GT Test Results](docs/TEST_MINI_RESULTS.md): baseline results on the SEE mini GT dataset.
 
-We provide a Google Drive folder that includes pretrained checkpoints, evaluation logs, and the corresponding experiment files for the released baselines. The package is organized by method, so you can quickly locate the checkpoint you need and reproduce the reported results with minimal setup.
+Chinese versions are also available:
 
-**Download link:**
+- [README_ZH.md](README_ZH.md)
+- [docs/TUTORIAL_ZH.md](docs/TUTORIAL_ZH.md)
+- [docs/CODABENCH_SUBMISSION_GUIDE_ZH.md](docs/CODABENCH_SUBMISSION_GUIDE_ZH.md)
+- [CODABENCH_README_ZH.md](CODABENCH_README_ZH.md)
 
-https://drive.google.com/drive/folders/1SWR9YVIrqFEkGGKrv3wSC5RqmMIEYjV2?usp=sharing
+## Related Links
 
-**Folder contents:**
+- **Workshop Website**: [https://eventbasemultimodalvision.github.io](https://eventbasemultimodalvision.github.io)
+- **Competition Page**: [https://www.codabench.org/competitions/16195/](https://www.codabench.org/competitions/16195/#/pages-tab)
+- **Competition Forum**: [https://www.codabench.org/forums/15944/](https://www.codabench.org/forums/15944/)
+- **Competition Report**: [https://arxiv.org/abs/2502.21120](https://arxiv.org/abs/2502.21120)
+- **IMU Registration Tool**: [https://github.com/yunfanLu/IMU-Registration-Tool](https://github.com/yunfanLu/IMU-Registration-Tool)
 
-```text
-.
-├── EIFT_AAAI_SEE
-│   ├── checkpoint-010.pth.tar
-│   └── py_SEE_eval_for_model.INFO.log
-├── eSl_SEE
-│   ├── checkpoint.pth.tar
-│   ├── py_main.INFO.log
-│   └── py_SEE_eval_for_model.cc2931668b9f.root.log.INFO.20240923-171527.3734002.log
-├── EvLight
-│   └── checkpoint.pth.tar
-├── SEENet_SEE
-│   ├── checkpoint.pth.tar
-│   ├── py_SEE_eval_for_model.INFO.log
-└── TEST_RESULTS.md
-```
+## Citation
 
-### 🖥️ Installation
-
-To get started with this repository, clone it using the following command:
-
-```bash
-git clone https://github.com/yunfanLu/SEE.git
-```
-
-Next, install the required dependencies:
-
-```bash
-pip install -r requirements.txt
-```
-
-You can then use the code to process images using our **SEE-Net** framework and adjust their brightness using the **SEE-600K** dataset.
-
----
-
-## 💬 Usage
-
-1. **Download the SEE-600K dataset**
-   
-   Download the SEE-600K dataset using the link provided above.
-
-3. **Data preprocessing and alignment**
-   Before training, the raw data must be properly extracted and aligned.
-
-   * For data extraction, follow the step-by-step instructions in the `tools/` directory.
-   * For temporal and spatial alignment, please refer to the IMU-based registration tool:
-     [https://github.com/yunfanLu/IMU-Registration-Tool](https://github.com/yunfanLu/IMU-Registration-Tool)
-     This tool provides millisecond-level alignment between RGB frames and events.
-   * If you download the dataset from Hugging Face, the data has already been aligned and can be used directly without additional registration.
-
-4. **Train the SEE-Net model**
-   We provide two training configurations, **SEE** and **SDE**, both located in the `options/` directory.
-
-   * The full training command is already written in
-     `options/SEE/SEENet_SEE.sh`.
-   * Before running, modify the paths in the script to match your local environment (dataset path, log directory, dependencies).
-   * A typical training command is:
-
-     ```bash
-     python see/main.py \
-       --yaml_file="options/SEE/SEENet_SEE.yaml" \
-       --log_dir="./logs/SEE/SEENet_SEE/" \
-       --alsologtostderr=True
-     ```
-   * During training, the model learns to reconstruct and adjust image brightness under a wide range of lighting conditions using event guidance.
-
-5. **Brightness adjustment with exposure prompts**
-   After training, the SEE model supports continuous brightness control via an exposure (brightness) prompt **B**.
-
-   * By changing the value of **B**, the model can generate images with different exposure levels from the same input.
-   * Internally, this is implemented by sampling different exposure prompts and decoding the corresponding outputs:
-
-     ```python
-     # 3. more exposure prompt
-     exposure_prompt = torch.ones(size=(B, 1, 1, 1)) * exposure_B
-     exposure_prompt = exposure_prompt.to(images.device)
-     exposure_normal_reconstructed = self._decoding(light_inr, exposure_prompt)
-     ```
-   * In evaluation mode, increasing **B** results in brighter outputs, while decreasing **B** produces darker images.
-   * This design enables pixel-level, continuous brightness adjustment as a post-processing step, without retraining the model.
-
-6. **Notes**
-
-   * The optimal operating range of the brightness prompt is typically around **B ≈ 0.5**, which corresponds to normal exposure.
-   * Extreme values of **B** are mainly intended for analysis and visualization, rather than as target outputs.
-   * The framework is designed for brightness adjustment rather than full HDR reconstruction.
-
-
----
-
-## 🖼️ Example Outputs
-
-Here are some example outputs generated using our framework:
-
-- **Low-Light Enhancement** 🌙: Images processed under very low-light conditions.
-- **High-Light Recovery** 🌞: Images processed under overexposed or bright light conditions.
-
-
-## IMU-Based Registration-Tool
-
-I released the registration tool separately to this repository - [Registration-Tool](https://github.com/yunfanLu/IMU-Registration-Tool).
-
----
-
-## 📄 Citation
-
-If you use the SEE-600K dataset or SEE-Net in your research, please cite our paper:
+If you use the SEE-600K dataset or SEE-Net in your research, please cite:
 
 ```bibtex
 @article{lu2025SEE,
@@ -237,25 +63,7 @@ If you use the SEE-600K dataset or SEE-Net in your research, please cite our pap
 }
 ```
 
----
+## Contact
 
-## 🐱‍🏍 Contributions
-
-We welcome contributions to this project! If you have any ideas or improvements, feel free to fork this repository and create a pull request. 💪
-
-- Bug fixes
-- New features
-- Improvements to documentation
-
----
-
-## 📞 Contact
-
-If you have any questions or need assistance, feel free to reach out to us!
-
-- **Yunfan Lu**: ylu066@connect.hkust-gz.edu.cn
+- **Yunfan Lu**: <ylu066@connect.hkust-gz.edu.cn>
 - **GitHub**: [yunfanLu](https://github.com/yunfanLu)
-
----
-
-✨ We hope you find the SEE project helpful and look forward to your contributions! 😄

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,0 +1,69 @@
+# SEE：See Everything Every Time
+
+**SEE** 是一个利用 RGB 图像与事件相机数据，在宽光照范围内进行自适应亮度调整的框架。本仓库提供 **SEE-Net** 的代码以及 **SEE-600K** 数据集相关资源。
+
+SEE-Net 使用事件信息作为引导，在低光、过曝、混合光照和高对比度场景中增强图像，同时保持场景结构和自然观感。
+
+## 主要特性
+
+- **事件引导的亮度调整**：结合 RGB 图像与事件数据，实现宽光照范围的图像增强。
+- **连续曝光控制**：通过曝光提示支持像素级亮度调整。
+- **轻量级基线模型**：SEE-Net 约有 **1.9M 参数**。
+- **大规模数据集支持**：基于 SEE-600K 构建，该数据集包含 **610,126 张图像及对应事件数据**，覆盖 **202 个真实场景**。
+
+## 数据集下载
+
+本项目使用的数据集已公开发布：
+
+- **SEE-600K 数据集**
+  - [OneDrive](https://hkustgz-my.sharepoint.com/:f:/g/personal/ylu066_connect_hkust-gz_edu_cn/EkNi59p2uHJFjxyeQraiVhgBSs1GnxK4DyCUP-uZhEspCA?e=ZpwOvY)
+  - [Hugging Face](https://huggingface.co/datasets/yunfanlu/SEE-600K)
+- **SDE 数据集**：[SDE Dataset GitHub](https://github.com/EthanLiang99/EvLight)
+
+## 预训练模型
+
+已发布基线方法的预训练权重、评测日志和实验文件可从 Google Drive 下载：
+
+<https://drive.google.com/drive/folders/1SWR9YVIrqFEkGGKrv3wSC5RqmMIEYjV2?usp=sharing>
+
+该文件夹按方法组织，包含 `EIFT_AAAI_SEE`、`eSl_SEE`、`EvLight` 和 `SEENet_SEE` 的权重，以及相关日志和 `TEST_RESULTS.md`。
+
+## 文档
+
+- [教程](docs/TUTORIAL_ZH.md)：环境配置、数据集准备、训练、评测、推理和常见问题。
+- [CodaBench 提交指南](docs/CODABENCH_SUBMISSION_GUIDE_ZH.md)：将结果打包并提交到 CodaBench 的逐步说明。
+- [CodaBench 页面说明](CODABENCH_README_ZH.md)：用于 SEE Challenge CodaBench 页面的一份简洁独立介绍。
+- [测试结果](docs/TEST_RESULTS.md)：SEE 数据集上的基线结果。
+- [Mini-GT 测试结果](docs/TEST_MINI_RESULTS.md)：SEE mini GT 数据集上的基线结果。
+
+英文版本也可查看：
+
+- [README.md](README.md)
+- [docs/TUTORIAL.md](docs/TUTORIAL.md)
+- [docs/CODABENCH_SUBMISSION_GUIDE.md](docs/CODABENCH_SUBMISSION_GUIDE.md)
+- [CODABENCH_README.md](CODABENCH_README.md)
+
+## 相关链接
+
+- **Workshop Website**: [https://eventbasemultimodalvision.github.io](https://eventbasemultimodalvision.github.io)
+- **Competition Page**: [https://www.codabench.org/competitions/16195/](https://www.codabench.org/competitions/16195/#/pages-tab)
+- **Competition Forum**: [https://www.codabench.org/forums/15944/](https://www.codabench.org/forums/15944/)
+- **Competition Report**: [https://arxiv.org/abs/2502.21120](https://arxiv.org/abs/2502.21120)
+- **IMU Registration Tool**: [https://github.com/yunfanLu/IMU-Registration-Tool](https://github.com/yunfanLu/IMU-Registration-Tool)
+
+## 引用
+
+如果您在研究中使用 SEE-600K 数据集或 SEE-Net，请引用：
+
+```bibtex
+@article{lu2025SEE,
+  title={SEE: See Everything Every Time - Adaptive Brightness Adjustment for Broad Light Range Images via Events},
+  author={Yunfan Lu, Xiaogang Xu, Hao Lu, Yanlin Qian, Pengteng Li, Huizai Yao, Bin Yang, Junyi Li, Qianyi Cai, Weiyu Guo, Hui Xiong},
+  year={2025},
+}
+```
+
+## 联系方式
+
+- **Yunfan Lu**: <ylu066@connect.hkust-gz.edu.cn>
+- **GitHub**: [yunfanLu](https://github.com/yunfanLu)

--- a/docs/CODABENCH_SUBMISSION_GUIDE.md
+++ b/docs/CODABENCH_SUBMISSION_GUIDE.md
@@ -1,75 +1,38 @@
-# Codabench Test Submission Workflow
+# CodaBench Submission Guide
 
-This document explains the complete workflow for the SEE project, including model training, inference/testing, organizing prediction results for the competition test set, and submitting them to Codabench.
+This guide explains how to prepare SEE prediction results and submit them to CodaBench. For environment setup, model training, evaluation, and inference, see [TUTORIAL.md](./TUTORIAL.md).
 
 ---
 
-## 1. Model Training
+## 1. Generate Inference Results
 
-Model training is launched through the corresponding shell script under the `options/SEE/` directory.
+Run inference with your trained model and save visualization results. The output directory is usually named `vis`.
 
-Taking **SEENet** as an example, the training command is:
+Before generating submission predictions, make sure the inference crop size in the corresponding YAML file is set to the original SEE image size:
 
-```bash
-sh options/SEE/SEENet_SEE.sh
-````
-
-Notes:
-
-* Different models usually have their own corresponding scripts;
-* To train another model, simply replace it with the corresponding `.sh` file;
-* Training-related configurations are usually defined in the `.yaml` file referenced by the script.
-
-
-## 2. Model Inference / Testing
-
-After model training is completed, testing/inference is still performed using the **testing part** of the corresponding model script.
-
-Taking **SEENet** as an example, the testing command also refers to:
-
-```bash
-sh options/SEE/SEENet_SEE.sh
-```
-```
-
-Notes:
-
-- During inference, use the **Test / testing section** in the script;
-- Before inference, check the corresponding YAML configuration;
-- **During inference, the crop width and height in the YAML file must be set to the original image size**.
-
-For the SEE dataset, they should be set as:
-
+```yaml
 crop_w: 346
 crop_h: 260
-
-This corresponds to the original image size:
-
-* Width: `346`
-* Height: `260`
-
-If the crop size during inference is not set to the original image size, the output results may not meet the requirements of the competition test set.
-
-
-## 3. Collect Prediction Images Corresponding to the Competition Test Set
-
-After inference is completed, a visualization result directory, usually named `vis`, will be generated.
-
-Next, you need to extract the prediction images corresponding to the **GT samples of the competition test set** from these testing results.
-
-The script used for this step is:
-
-```bash
-codabench/collect_codabench_pred.py
 ```
 
-Usage:
+This corresponds to:
+
+- Width: `346`
+- Height: `260`
+
+If the inference crop size is not set to the original image size, the output may not match the competition test-set requirements.
+
+---
+
+## 2. Collect Competition Prediction Images
+
+Use the collection script to extract the prediction images that correspond to the competition test-set ground-truth samples:
 
 ```bash
 python codabench/collect_codabench_pred.py ${prediction_vis_directory} ${output_directory}
 ```
 
-For example:
+Example:
 
 ```bash
 python codabench/collect_codabench_pred.py /path/to/vis /path/to/output_dir
@@ -77,75 +40,67 @@ python codabench/collect_codabench_pred.py /path/to/vis /path/to/output_dir
 
 Arguments:
 
-* `${prediction_vis_directory}`: the `vis` folder generated after model inference;
-* `${output_directory}`: the folder used to save the collected prediction results for competition submission.
+- `${prediction_vis_directory}`: the `vis` folder generated after model inference;
+- `${output_directory}`: the folder used to save the collected prediction results for CodaBench submission.
 
-After the script finishes, the output directory will contain the organized prediction results ready for competition submission.
+The script uses the default list `codabench/SEE_gt_mini.txt`. To use another list, pass `--list`:
+
+```bash
+python codabench/collect_codabench_pred.py /path/to/vis /path/to/output_dir --list /path/to/list.txt
+```
+
+If the output directory already exists and you want to replace it, pass `--overwrite`:
+
+```bash
+python codabench/collect_codabench_pred.py /path/to/vis /path/to/output_dir --overwrite
+```
+
+After the script finishes, the output directory contains the organized prediction results for submission.
 
 ---
 
-## 4. Package and Submit to Codabench
+## 3. Package the Submission
 
-After obtaining the output directory from Step 3, you need to package this folder into a zip file and upload it to the submission page on Codabench.
-
-You can use the following command to create the zip file:
+Create a zip file from the collected output directory:
 
 ```bash
 zip -r submission.zip ${output_directory}
 ```
 
-For example:
+Example:
 
 ```bash
 zip -r submission.zip /path/to/output_dir
 ```
 
-After that:
+Before uploading, check that:
 
-1. Open the Codabench competition page;
-2. Go to the **submission** page;
-3. Upload the packaged `submission.zip`;
-4. Submit it.
+- the number of output files is correct;
+- the filename format matches the expected competition format;
+- the directory structure inside the zip file is correct;
+- the images are saved at the original SEE image size.
+
+---
+
+## 4. Upload to CodaBench
+
+1. Open the CodaBench competition page: <https://www.codabench.org/competitions/16195/>.
+2. Go to the **submission** page.
+3. Upload `submission.zip`.
+4. Submit the file.
+
+If the CodaBench submission status is abnormal, first check the zip file's internal directory structure and file naming.
 
 ---
 
 ## 5. Workflow Summary
 
-The complete workflow is as follows:
+```bash
+# 1. Collect prediction images for submission
+python codabench/collect_codabench_pred.py ${prediction_vis_directory} ${output_directory}
 
-1. Train the model:
+# 2. Package the collected folder
+zip -r submission.zip ${output_directory}
 
-   ```bash
-   sh options/SEE/SEENet_SEE.sh
-   ```
-
-2. Use the testing section in the script for inference;
-
-3. Make sure the image size during inference is set to the original size in the YAML file:
-
-   ```yaml
-   crop_w: 346
-   crop_h: 260
-   ```
-
-4. Use the following command to collect the prediction results required for competition submission:
-
-   ```bash
-   python codabench/collect_codabench_pred.py ${prediction_vis_directory} ${output_directory}
-   ```
-
-5. Package the output folder into a zip file:
-
-   ```bash
-   zip -r submission.zip ${output_directory}
-   ```
-
-6. Upload the zip file to the Codabench submission page.
-
----
-
-## 6. Notes
-
-* It is recommended to first check the comments in the corresponding model script before training and testing;
-* Before submission, it is recommended to check whether the number of output files, filename format, and directory structure meet the competition requirements;
-* If the Codabench submission status is abnormal, first check whether the internal directory structure of the zip file and the file naming are correct.
+# 3. Upload submission.zip on CodaBench
+```

--- a/docs/CODABENCH_SUBMISSION_GUIDE_ZH.md
+++ b/docs/CODABENCH_SUBMISSION_GUIDE_ZH.md
@@ -1,77 +1,38 @@
-# Codabench 测试提交流程中文说明
+# CodaBench 提交指南
 
-本文档用于说明 SEE 项目中，从模型训练、推理测试，到整理比赛测试集预测结果并提交到 Codabench 的完整流程。
-
----
-
-## 1. 模型训练
-
-模型训练统一通过 `options/SEE/` 目录下对应模型的 shell 脚本启动。
-
-以 **SEENet** 为例，训练命令为：
-
-```bash
-sh options/SEE/SEENet_SEE.sh
-```
-
-说明：
-- 不同模型通常都有各自对应的脚本；
-- 如果需要训练其他模型，只需要替换成对应的 `.sh` 文件即可；
-- 训练相关配置通常写在该脚本所引用的 `.yaml` 文件中。
+本指南说明如何准备 SEE 预测结果并提交到 CodaBench。环境配置、模型训练、评测和推理请见 [TUTORIAL_ZH.md](./TUTORIAL_ZH.md)。
 
 ---
 
-## 2. 模型推理 / Inference
+## 1. 生成推理结果
 
-模型训练完成后，进行测试推理时，仍然调用对应模型脚本中的**测试部分**。
+使用训练好的模型运行推理并保存可视化结果。输出目录通常命名为 `vis`。
 
-以 **SEENet** 为例，测试代码同样参考：
-
-```bash
-sh options/SEE/SEENet_SEE.sh
-```
-
-需要注意：
-
-- 推理时请使用该脚本中的 **Test / 测试部分**；
-- 推理前需要检查对应的 YAML 配置；
-- **inference 时，yaml 中的 crop 图像宽高必须设置为原图大小**。
-
-对于 SEE 数据集，这里需要设置为：
+在生成提交预测结果之前，请确保对应 YAML 文件中的推理裁剪尺寸设置为 SEE 原始图像大小：
 
 ```yaml
 crop_w: 346
 crop_h: 260
 ```
 
-也就是原图大小：
+这对应于：
 
-- 宽 `346`
-- 高 `260`
+- 宽度：`346`
+- 高度：`260`
 
-如果推理时 crop 大小不是原图大小，可能会导致输出结果与比赛测试集要求不一致。
+如果推理裁剪尺寸没有设置为原始图像大小，输出可能不符合比赛测试集要求。
 
 ---
 
-## 3. 从可视化结果中抽取比赛测试集对应预测图
+## 2. 收集比赛预测图像
 
-完成推理后，通常会得到模型的可视化结果目录（`vis` 文件夹）。
-
-接下来，需要从这些测试结果中，抽取出**本次比赛 test 集对应 GT 的预测图像**。
-
-这里使用的脚本是：
+使用收集脚本抽取与比赛测试集 ground-truth 样本对应的预测图像：
 
 ```bash
-codabench/collect_codabench_pred.py
+python codabench/collect_codabench_pred.py ${prediction_vis_directory} ${output_directory}
 ```
 
-使用方式：
-
-```bash
-python codabench/collect_codabench_pred.py ${predict的vis目录} ${输出文件夹路径}
-```
-
-例如：
+示例：
 
 ```bash
 python codabench/collect_codabench_pred.py /path/to/vis /path/to/output_dir
@@ -79,66 +40,67 @@ python codabench/collect_codabench_pred.py /path/to/vis /path/to/output_dir
 
 参数说明：
 
-- `${predict的vis目录}`：模型推理后生成的 `vis` 文件夹；
-- `${输出文件夹路径}`：用于保存抽取后的比赛提交结果。
+- `${prediction_vis_directory}`：模型推理后生成的 `vis` 文件夹；
+- `${output_directory}`：用于保存收集后 CodaBench 提交结果的文件夹。
 
-执行完成后，输出文件夹中会保存整理好的、可用于比赛提交的预测结果。
+脚本默认使用列表 `codabench/SEE_gt_mini.txt`。如果要使用其他列表，请传入 `--list`：
+
+```bash
+python codabench/collect_codabench_pred.py /path/to/vis /path/to/output_dir --list /path/to/list.txt
+```
+
+如果输出目录已经存在且需要替换，请传入 `--overwrite`：
+
+```bash
+python codabench/collect_codabench_pred.py /path/to/vis /path/to/output_dir --overwrite
+```
+
+脚本执行完成后，输出目录中会包含整理好的提交结果。
 
 ---
 
-## 4. 打包并提交到 Codabench
+## 3. 打包提交文件
 
-当第 3 步得到输出文件夹后，需要将该文件夹打包为 zip 文件，然后上传到 Codabench 的 submission 页面。
-
-可以使用如下命令进行打包：
+将收集后的输出目录打包为 zip 文件：
 
 ```bash
-zip -r submission.zip ${输出文件夹路径}
+zip -r submission.zip ${output_directory}
 ```
 
-例如：
+示例：
 
 ```bash
 zip -r submission.zip /path/to/output_dir
 ```
 
-完成后：
+上传前，请检查：
 
-1. 打开 Codabench 比赛页面；
-2. 进入 **submission** 页面；
-3. 上传打包好的 `submission.zip`；
-4. 提交即可。
+- 输出文件数量是否正确；
+- 文件名格式是否符合比赛要求；
+- zip 文件内部目录结构是否正确；
+- 图像是否保存为 SEE 原始图像大小。
+
+---
+
+## 4. 上传到 CodaBench
+
+1. 打开 CodaBench 比赛页面：<https://www.codabench.org/competitions/16195/>。
+2. 进入 **submission** 页面。
+3. 上传 `submission.zip`。
+4. 提交文件。
+
+如果 CodaBench 提交状态异常，请先检查 zip 文件内部目录结构和文件命名。
 
 ---
 
 ## 5. 流程总结
 
-完整流程如下：
+```bash
+# 1. 收集用于提交的预测图像
+python codabench/collect_codabench_pred.py ${prediction_vis_directory} ${output_directory}
 
-1. 训练模型
-   ```bash
-   sh options/SEE/SEENet_SEE.sh
-   ```
-2. 使用脚本中的测试部分进行 inference；
-3. 确保 YAML 中推理时的图像大小设置为原图大小：
-   ```yaml
-   crop_w: 346
-   crop_h: 260
-   ```
-4. 使用如下命令抽取比赛提交所需预测结果：
-   ```bash
-   python codabench/collect_codabench_pred.py ${predict的vis目录} ${输出文件夹路径}
-   ```
-5. 将输出文件夹打包为 zip：
-   ```bash
-   zip -r submission.zip ${输出文件夹路径}
-   ```
-6. 将 zip 上传到 Codabench submission 页面。
+# 2. 打包收集后的文件夹
+zip -r submission.zip ${output_directory}
 
----
-
-## 6. 备注
-
-- 训练和测试都建议优先查看对应模型脚本中的注释；
-- 提交前建议先检查输出文件数量、命名格式以及目录结构是否符合比赛要求；
-- 如果 Codabench 提交后状态异常，可优先检查 zip 内部目录结构和文件命名是否正确。
+# 3. 在 CodaBench 上传 submission.zip
+```

--- a/docs/TEST_MINI_RESULTS.md
+++ b/docs/TEST_MINI_RESULTS.md
@@ -55,16 +55,6 @@ This document summarizes baseline test results on the SEE mini GT dataset.
   - Normal-Normal: 162
 - Among the tested baselines, SEENet achieves the best overall performance on the SEE mini GT dataset.
 
-## How to Run Evaluation
+## Evaluation Usage
 
-To evaluate your own model with an explicit GT root:
-
-```bash
-python tools/2-eval-for-vis-folder/SEE_eval_for_model_with_gt_root.py \
-    --root="/path/to/your/eval/folder" \
-    --gt_root="/path/to/your/gt/root" \
-    --log_dir="/path/to/your/log/dir" \
-    --alsologtostderr=True
-```
-
-For more details, see [TUTORIAL.md](./TUTORIAL.md).
+For evaluation commands and usage details, see [TUTORIAL.md](./TUTORIAL.md#6-evaluate-or-run-inference).

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -51,15 +51,6 @@ This document summarizes baseline test results on the SEE dataset.
 - Per-lighting-condition results are reported as `(PSNR, SSIM, PSNR-Linear_N, L1)`.
 - Among the tested baselines, SEENet achieves the best overall performance on the SEE dataset.
 
-## How to Run Evaluation
+## Evaluation Usage
 
-To evaluate your own model:
-
-```bash
-python tools/2-eval-for-vis-folder/SEE_eval_for_model.py \
-    --root="/path/to/your/vis/folder" \
-    --log_dir="/path/to/your/log/dir" \
-    --alsologtostderr=True
-```
-
-For more details, see [TUTORIAL.md](./TUTORIAL.md).
+For evaluation commands and usage details, see [TUTORIAL.md](./TUTORIAL.md#6-evaluate-or-run-inference).

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1,27 +1,25 @@
-# EBMV 2026 Low-Level Imaging Challenge: Getting Started Tutorial
+# SEE Tutorial
 
-This tutorial guides you through the entire process of participating in the **EBMV 2026 Low-Level Imaging Challenge**, from dataset preparation to running the baseline model.
+This tutorial explains how to set up the SEE repository, prepare the SEE-600K dataset, run baseline training, evaluate checkpoints, and generate inference outputs.
 
-- **Competition Page**: <https://www.codabench.org/competitions/16195/>
-- **Competition Report**: <https://arxiv.org/abs/2502.21120>
-- **Baseline Code**: <https://github.com/yunfanLu/SEE>
-- **Dataset**: <https://huggingface.co/datasets/yunfanlu/SEE-600K>
-- **Workshop**: <https://eventbasemultimodalvision.github.io>
+For project overview, dataset links, pretrained model links, and related resources, see [README.md](../README.md). For CodaBench packaging and upload instructions, see [CODABENCH_SUBMISSION_GUIDE.md](./CODABENCH_SUBMISSION_GUIDE.md).
 
-***
+---
 
-## 1. Download and Prepare the Dataset
+## 1. Clone the Repository
 
-### 1.1 Download SEE-600K
+```bash
+git clone https://github.com/yunfanLu/SEE.git
+cd SEE
+```
 
-The SEE-600K dataset is available on HuggingFace and OneDrive:
+---
 
-| Source      | Link                                                                                                                                            |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| HuggingFace | <https://huggingface.co/datasets/yunfanlu/SEE-600K>                                                                                             |
-| OneDrive    | [Link](https://hkustgz-my.sharepoint.com/:f:/g/personal/ylu066_connect_hkust-gz_edu_cn/EkNi59p2uHJFjxyeQraiVhgBSs1GnxK4DyCUP-uZhEspCA?e=ZpwOvY) |
+## 2. Prepare the Dataset
 
-**Option A: Download from HuggingFace (Recommended)**
+Download SEE-600K from one of the links listed in [README.md](../README.md#dataset-download). The Hugging Face version is already aligned and classified, so no additional registration is required.
+
+### 2.1 Download with Hugging Face CLI
 
 ```bash
 # Install huggingface_hub
@@ -31,22 +29,18 @@ pip install huggingface_hub
 hf download yunfanlu/SEE-600K --local-dir ./SEE-600K
 ```
 
-**Option B: Download specific subsets**
-
-If you have limited storage or bandwidth, you can download only the data you need:
+If you have limited storage or bandwidth, download only the required subset:
 
 ```bash
 # Download a specific split (e.g., RoboticArm)
 hf download yunfanlu/SEE-600K --include "RoboticArm/*" --local-dir ./SEE-600K
 ```
 
-> **Note**: If you download from HuggingFace, the data has already been aligned and can be used directly without additional registration.
-
-### 1.2 Dataset Structure
+### 2.2 Expected Dataset Structure
 
 After downloading, the dataset should have the following structure:
 
-```
+```text
 SEE-600K/
 └── RoboticArm/
     ├── 000-indoor_ceiling_table_light/       # Group folder (scene)
@@ -65,20 +59,20 @@ SEE-600K/
     └── ...
 ```
 
-### 1.3 Train/Test Split
+### 2.3 Train/Test Split
 
-The dataset contains 202 scenarios. The following groups are reserved for **testing** (do NOT use them for training):
+The dataset contains 202 scenarios. The following groups are reserved for **testing** and must not be used for training:
 
-| Type    | Groups                                                                                                       |
-| ------- | ------------------------------------------------------------------------------------------------------------ |
-| Indoor  | 000, 001, 002, 006, 012, 018, 030, 042, 048, 054, 060, 065, 070, 074, 075                                    |
+| Type | Groups |
+| --- | --- |
+| Indoor | 000, 001, 002, 006, 012, 018, 030, 042, 048, 054, 060, 065, 070, 074, 075 |
 | Outdoor | 100, 106, 112, 118, 124, 130, 136, 142, 148, 154, 160, 166, 173, 184, 189, 194, 200, 206, 212, 217, 222, 225 |
 
 All other groups are used for **training**.
 
-### 1.4 (Optional) Raw Data Processing
+### 2.4 Optional Raw Data Processing
 
-If you download raw `.aedat4` files instead of the pre-processed HuggingFace version, you need to process them:
+If you download raw `.aedat4` files instead of the pre-processed Hugging Face version, process them as follows:
 
 ```bash
 # Step 0: Extract frames, events, and IMU from .aedat4 files
@@ -96,22 +90,13 @@ python registration/main.py --video_group_root="dataset/RoboticArm/"
 python registration/exposure_classifier.py --root="dataset/RoboticArm/"
 ```
 
-> **Note**: If you download from HuggingFace, these steps are **NOT** needed — the data is already aligned and classified.
+The IMU registration tool is also available at <https://github.com/yunfanLu/IMU-Registration-Tool>.
 
-***
+---
 
-## 2. Clone the SEE Codebase
+## 3. Set Up the Python Environment
 
-```bash
-git clone https://github.com/yunfanLu/SEE.git
-cd SEE
-```
-
-***
-
-## 3. Install Python Environment
-
-### 3.1 Create a Conda Environment (Recommended)
+### 3.1 Create a Conda Environment
 
 ```bash
 conda create -n see python=3.10 -y
@@ -124,9 +109,9 @@ conda activate see
 pip install -r requirements.txt
 ```
 
-The `requirements.txt` includes:
+The `requirements.txt` file includes:
 
-```
+```text
 PyYAML
 torch
 absl-py
@@ -143,23 +128,19 @@ einops
 kornia
 ```
 
-### 3.3 Verify Installation
+### 3.3 Verify the Installation
 
 ```bash
 python -c "import torch; print(f'PyTorch: {torch.__version__}'); print(f'CUDA available: {torch.cuda.is_available()}')"
 ```
 
-Make sure CUDA is available for GPU training.
+CUDA should be available for GPU training.
 
-***
+---
 
-## 4. Run a Baseline Experiment
+## 4. Configure the Baseline
 
-### 4.1 Configure the Dataset Path
-
-Before training, you need to modify the dataset path in the YAML configuration file to match your local setup.
-
-Edit `options/SEE/SEENet_SEE.yaml` and update the `DATASET.root` field:
+Edit `options/SEE/SEENet_SEE.yaml` and update `DATASET.root` to match your local dataset path:
 
 ```yaml
 DATASET:
@@ -167,16 +148,37 @@ DATASET:
   root: /path/to/your/SEE-600K/RoboticArm/    # <-- Change this to your dataset path
 ```
 
-For example, if your dataset is at `/home/user/data/SEE-600K/RoboticArm/`:
+For example:
 
 ```yaml
 DATASET:
   root: /home/user/data/SEE-600K/RoboticArm/
 ```
 
-### 4.2 Training
+The default baseline configuration in `options/SEE/SEENet_SEE.yaml` is:
 
-Run the baseline training:
+| Parameter | Value | Description |
+| --- | --- | --- |
+| `TRAIN_BATCH_SIZE` | 2 | Batch size per GPU |
+| `VAL_BATCH_SIZE` | 2 | Validation batch size |
+| `START_EPOCH` | 0 | Starting epoch |
+| `END_EPOCH` | 20 | Total training epochs |
+| `OPTIMIZER.NAME` | Adam | Optimizer |
+| `OPTIMIZER.LR` | 0.0001 | Learning rate |
+| `OPTIMIZER.LR_SCHEDULER` | cosine | LR scheduler |
+| `LOSS` | L1-Charbonnier + Gradient | Loss functions |
+| `DATASET.crop_h` | 128 | Crop height |
+| `DATASET.crop_w` | 256 | Crop width |
+| `MODEL.NAME` | SEENet | Model architecture |
+| `MODEL.loop` | 10 | Sparse encoder iterations |
+| `MODEL.C1/C2` | 96 | Channel dimensions |
+| `MIX_PRECISION` | true | Mixed precision training |
+
+---
+
+## 5. Train SEE-Net
+
+Run the baseline training command:
 
 ```bash
 export PYTHONPATH="./":$PYTHONPATH
@@ -187,7 +189,13 @@ python see/main.py \
   --alsologtostderr=True
 ```
 
-**Multi-GPU training** (if you have multiple GPUs):
+You can also launch the provided script:
+
+```bash
+sh options/SEE/SEENet_SEE.sh
+```
+
+For multi-GPU training, set the visible GPU IDs before running the same command:
 
 ```bash
 export CUDA_VISIBLE_DEVICES="0,1"
@@ -200,42 +208,32 @@ python see/main.py \
 
 The code uses `nn.DataParallel` for multi-GPU training automatically.
 
-### 4.3 Key Training Configuration
-
-The default configuration in `options/SEE/SEENet_SEE.yaml`:
-
-| Parameter                | Value                     | Description               |
-| ------------------------ | ------------------------- | ------------------------- |
-| `TRAIN_BATCH_SIZE`       | 2                         | Batch size per GPU        |
-| `VAL_BATCH_SIZE`         | 2                         | Validation batch size     |
-| `START_EPOCH`            | 0                         | Starting epoch            |
-| `END_EPOCH`              | 20                        | Total training epochs     |
-| `OPTIMIZER.NAME`         | Adam                      | Optimizer                 |
-| `OPTIMIZER.LR`           | 0.0001                    | Learning rate             |
-| `OPTIMIZER.LR_SCHEDULER` | cosine                    | LR scheduler              |
-| `LOSS`                   | L1-Charbonnier + Gradient | Loss functions            |
-| `DATASET.crop_h`         | 128                       | Crop height               |
-| `DATASET.crop_w`         | 256                       | Crop width                |
-| `MODEL.NAME`             | SEENet                    | Model architecture        |
-| `MODEL.loop`             | 10                        | Sparse encoder iterations |
-| `MODEL.C1/C2`            | 96                        | Channel dimensions        |
-| `MIX_PRECISION`          | true                      | Mixed precision training  |
-
-### 4.4 Monitor Training with TensorBoard
+### 5.1 Monitor Training with TensorBoard
 
 ```bash
 tensorboard --logdir=./logs/SEE/SEENet_SEE/ --port=6006 --bind_all
 ```
 
-Then open `http://localhost:6006` in your browser.
-
-If you are on a remote server, use SSH port forwarding:
+Then open `http://localhost:6006` in your browser. On a remote server, use SSH port forwarding:
 
 ```bash
 ssh -L 6006:localhost:6006 user@server_ip
 ```
 
-### 4.5 Testing / Validation
+### 5.2 Resume Training from a Checkpoint
+
+```bash
+python see/main.py \
+  --yaml_file="options/SEE/SEENet_SEE.yaml" \
+  --log_dir="./logs/SEE/SEENet_SEE/" \
+  --alsologtostderr=True \
+  --RESUME_PATH="./logs/SEE/SEENet_SEE/checkpoint.pth.tar" \
+  --RESUME_SET_EPOCH=True
+```
+
+---
+
+## 6. Evaluate or Run Inference
 
 After training, run validation with a trained checkpoint:
 
@@ -250,120 +248,89 @@ python see/main.py \
   --VAL_BATCH_SIZE=4
 ```
 
-Key flags for testing:
+Key testing flags:
 
-| Flag                   | Description                                  |
-| ---------------------- | -------------------------------------------- |
-| `--TEST_ONLY=True`     | Skip training, run validation only           |
-| `--VISUALIZE=True`     | Save output images during validation         |
-| `--RESUME_PATH=<path>` | Path to trained checkpoint                   |
-| `--VAL_BATCH_SIZE=4`   | Can increase batch size for faster inference |
+| Flag | Description |
+| --- | --- |
+| `--TEST_ONLY=True` | Skip training and run validation only |
+| `--VISUALIZE=True` | Save output images during validation |
+| `--RESUME_PATH=<path>` | Path to the trained checkpoint |
+| `--VAL_BATCH_SIZE=4` | Increase batch size for faster inference if memory allows |
 
-### 4.6 Brightness Adjustment with Exposure Prompts
+To evaluate a visualization folder, run:
 
-The SEE model supports continuous brightness control via an exposure prompt **B**:
+```bash
+python tools/2-eval-for-vis-folder/SEE_eval_for_model.py \
+    --root="/path/to/your/vis/folder" \
+    --log_dir="/path/to/your/log/dir" \
+    --alsologtostderr=True
+```
 
-- **B ≈ 0.5**: Normal exposure (recommended)
-- **B > 0.5**: Brighter output
-- **B < 0.5**: Darker output
+To evaluate with an explicit ground-truth root, run:
 
-This is controlled in the model's forward pass:
+```bash
+python tools/2-eval-for-vis-folder/SEE_eval_for_model_with_gt_root.py \
+    --root="/path/to/your/eval/folder" \
+    --gt_root="/path/to/your/gt/root" \
+    --log_dir="/path/to/your/log/dir" \
+    --alsologtostderr=True
+```
+
+Baseline metric summaries are available in [TEST_RESULTS.md](./TEST_RESULTS.md) and [TEST_MINI_RESULTS.md](./TEST_MINI_RESULTS.md).
+
+---
+
+## 7. Use Exposure Prompts for Brightness Adjustment
+
+SEE-Net supports continuous brightness control through an exposure prompt **B**:
+
+- **B ≈ 0.5**: normal exposure and the typical operating range;
+- **B > 0.5**: brighter output;
+- **B < 0.5**: darker output.
+
+The model applies the prompt during decoding:
 
 ```python
 exposure_prompt = torch.ones(size=(B, 1, 1, 1)) * exposure_B
-output = model._decoding(light_inr, exposure_prompt)
+exposure_prompt = exposure_prompt.to(images.device)
+exposure_normal_reconstructed = self._decoding(light_inr, exposure_prompt)
 ```
 
 During testing, the model generates three types of output:
 
-- **PRD**: Prediction using target exposure prompt
-- **SLR**: Self-supervised reconstruction (using input's own mean)
-- **NLR**: Standard light reconstruction (using fixed B=0.4)
+- **PRD**: prediction using the target exposure prompt;
+- **SLR**: self-supervised reconstruction using the input mean;
+- **NLR**: standard-light reconstruction using fixed `B=0.4`.
 
-***
+Extreme values of **B** are mainly intended for analysis and visualization rather than as target outputs. The framework is designed for brightness adjustment rather than full HDR reconstruction.
 
-## 5. Prepare Submission
+---
 
-### 5.1 Submission Format
+## 8. FAQ
 
-Each submission should be a ZIP file with the following structure:
+### How much GPU memory is needed?
 
-```
-submission.zip
-└── results/
-    ├── scene_000001.png
-    ├── scene_000002.png
-    ├── scene_000003.png
-    └── ...
-```
+The baseline SEENet model has approximately **1.9M parameters**. With batch size 2 and crop size 128×256, it requires approximately **6-8 GB** of GPU memory. Adjust `TRAIN_BATCH_SIZE` and crop size based on your hardware.
 
-### 5.2 Requirements
+### Can I use external data?
 
-1. Output filenames must match the input sample IDs
-2. Images should be saved as **PNG** files
-3. Output images should be **RGB** images
-4. Output resolution must match the input/reference resolution
-5. Do not change the folder structure
-6. Do not include extra files unless explicitly required
+Yes. External training data, pretrained models, and synthetic data are allowed, but they must be **clearly reported** in the final technical report.
 
-### 5.3 Evaluation Metrics
+### How long does training take?
 
-| Metric | Description                         | Priority              |
-| ------ | ----------------------------------- | --------------------- |
-| PSNR   | Pixel-level reconstruction accuracy | **Primary** (ranking) |
-| SSIM   | Structural similarity               | Secondary             |
-| LPIPS  | Perceptual similarity               | Secondary             |
+With a single A100 GPU, baseline training for 20 epochs takes approximately **10-15 hours**. Training time varies by GPU.
 
-***
+### Why is TensorBoard empty?
 
-## 6. Tips and FAQ
+Check the following:
 
-### Q: How much GPU memory is needed?
+1. `--logdir` points to the directory that contains `events.out.tfevents.*` files.
+2. Training has started and logged at least one epoch; check `LOG_INTERVAL` in the config.
+3. If using a remote server, SSH port forwarding is configured correctly.
 
-The baseline model (SEENet) has only **1.9M parameters**. With batch size 2 and crop size 128×256, it requires approximately **6-8 GB** GPU memory. You can adjust `TRAIN_BATCH_SIZE` and crop size based on your hardware.
+---
 
-### Q: Can I use external data?
-
-Yes, external training data, pretrained models, and synthetic data are allowed, but they must be **clearly reported** in the final technical report.
-
-### Q: How long does training take?
-
-With a single A100 GPU, the baseline training (20 epochs) takes approximately **10-15 hours**. Training time varies depending on your GPU.
-
-### Q: The TensorBoard page is empty / no curves
-
-Make sure:
-
-1. The `--logdir` path points to the correct directory containing `events.out.tfevents.*` files
-2. Training has started and logged at least one epoch (check `LOG_INTERVAL` in the config)
-3. If using a remote server, ensure port forwarding is set up correctly
-
-### Q: How to resume training from a checkpoint?
-
-```bash
-python see/main.py \
-  --yaml_file="options/SEE/SEENet_SEE.yaml" \
-  --log_dir="./logs/SEE/SEENet_SEE/" \
-  --alsologtostderr=True \
-  --RESUME_PATH="./logs/SEE/SEENet_SEE/checkpoint.pth.tar" \
-  --RESUME_SET_EPOCH=True
-```
-
-***
-
-## 7. Important Dates
-
-| Date          | Event                                     |
-| ------------- | ----------------------------------------- |
-| May 15, 2026  | Challenge website opens                   |
-| May 25, 2026  | Validation server online                  |
-| June 25, 2026 | Test data released and test server online |
-| July 3, 2026  | Test submission deadline                  |
-| July 10, 2026 | Results announcement (tentative)          |
-
-***
-
-## 8. Citation
+## 9. Citation
 
 If you use the SEE-600K dataset or SEE-Net, please cite:
 
@@ -375,11 +342,9 @@ If you use the SEE-600K dataset or SEE-Net, please cite:
 }
 ```
 
-***
+---
 
-## 9. Contact
+## 10. Contact
 
 - **Yunfan Lu**: <ylu066@connect.hkust-gz.edu.cn>
 - **GitHub**: [yunfanLu](https://github.com/yunfanLu)
-- **Competition Forum**: <https://www.codabench.org/forums/15944/>
-

--- a/docs/TUTORIAL_ZH.md
+++ b/docs/TUTORIAL_ZH.md
@@ -1,0 +1,350 @@
+# SEE 教程
+
+本教程说明如何配置 SEE 仓库、准备 SEE-600K 数据集、运行基线训练、评测模型权重并生成推理结果。
+
+项目概览、数据集链接、预训练模型链接和相关资源请见 [README_ZH.md](../README_ZH.md)。CodaBench 打包和上传说明请见 [CODABENCH_SUBMISSION_GUIDE_ZH.md](./CODABENCH_SUBMISSION_GUIDE_ZH.md)。
+
+---
+
+## 1. 克隆仓库
+
+```bash
+git clone https://github.com/yunfanLu/SEE.git
+cd SEE
+```
+
+---
+
+## 2. 准备数据集
+
+请从 [README_ZH.md](../README_ZH.md#数据集下载) 中列出的链接下载 SEE-600K。Hugging Face 版本已经完成对齐和分类，因此不需要额外的配准步骤。
+
+### 2.1 使用 Hugging Face CLI 下载
+
+```bash
+# 安装 huggingface_hub
+pip install huggingface_hub
+
+# 下载完整数据集
+hf download yunfanlu/SEE-600K --local-dir ./SEE-600K
+```
+
+如果存储空间或带宽有限，可以只下载所需子集：
+
+```bash
+# 下载指定子集（例如 RoboticArm）
+hf download yunfanlu/SEE-600K --include "RoboticArm/*" --local-dir ./SEE-600K
+```
+
+### 2.2 预期数据集结构
+
+下载后，数据集结构应如下所示：
+
+```text
+SEE-600K/
+└── RoboticArm/
+    ├── 000-indoor_ceiling_table_light/       # 组文件夹（场景）
+    │   ├── registrate_result.json            # IMU 配准时间戳
+    │   ├── exposure_state.json               # 每个视频的曝光分类
+    │   ├── video_name_1/                     # 一段视频录制
+    │   │   ├── frame_event/
+    │   │   │   ├── <timestamp>_<ts_start>_<ts_end>_<ts_exp_start>_<ts_exp_end>.png  # RGB 图像帧
+    │   │   │   ├── <ts_start>_<ts_end>.npy          # 事件数据（N x 4：t, x, y, polarity）
+    │   │   │   └── <ts_start>_<ts_end>_vis.png      # 事件可视化
+    │   │   └── imu.npy                       # IMU 数据
+    │   ├── video_name_2/
+    │   │   └── ...
+    │   └── ...
+    ├── 001-indoor_wall_displayboard_wood_luggage/
+    └── ...
+```
+
+### 2.3 训练/测试划分
+
+数据集包含 202 个场景。以下组保留为**测试集**，不得用于训练：
+
+| 类型 | 组编号 |
+| --- | --- |
+| 室内 | 000, 001, 002, 006, 012, 018, 030, 042, 048, 054, 060, 065, 070, 074, 075 |
+| 室外 | 100, 106, 112, 118, 124, 130, 136, 142, 148, 154, 160, 166, 173, 184, 189, 194, 200, 206, 212, 217, 222, 225 |
+
+其余所有组用于**训练**。
+
+### 2.4 可选：原始数据处理
+
+如果下载的是原始 `.aedat4` 文件，而不是已经预处理的 Hugging Face 版本，请按如下步骤处理：
+
+```bash
+# Step 0: 从 .aedat4 文件中提取图像帧、事件和 IMU
+python tools/0-dataset-preprocess/0-extract_data_from_aedat4/extract_aedat4.py \
+    --aedat_folder="dataset/raw_aedat4/" \
+    --video_folder="dataset/processed/"
+
+# Step 1-2: IMU 标定（用于配准）
+python tools/0-dataset-preprocess/2-imu-calibration/cal_constant_bias.py
+
+# Step 3: 基于 IMU 的时间配准
+python registration/main.py --video_group_root="dataset/RoboticArm/"
+
+# Step 4: 曝光分类
+python registration/exposure_classifier.py --root="dataset/RoboticArm/"
+```
+
+IMU 配准工具也可在 <https://github.com/yunfanLu/IMU-Registration-Tool> 获取。
+
+---
+
+## 3. 配置 Python 环境
+
+### 3.1 创建 Conda 环境
+
+```bash
+conda create -n see python=3.10 -y
+conda activate see
+```
+
+### 3.2 安装依赖
+
+```bash
+pip install -r requirements.txt
+```
+
+`requirements.txt` 文件包含：
+
+```text
+PyYAML
+torch
+absl-py
+easydict
+pudb
+opencv-python
+numpy
+timm
+expecttest
+tensorboard
+scipy
+numba
+einops
+kornia
+```
+
+### 3.3 验证安装
+
+```bash
+python -c "import torch; print(f'PyTorch: {torch.__version__}'); print(f'CUDA available: {torch.cuda.is_available()}')"
+```
+
+进行 GPU 训练时，CUDA 应可用。
+
+---
+
+## 4. 配置基线模型
+
+编辑 `options/SEE/SEENet_SEE.yaml`，将 `DATASET.root` 更新为本地数据集路径：
+
+```yaml
+DATASET:
+  NAME: see_everything_everytime_dataset
+  root: /path/to/your/SEE-600K/RoboticArm/    # <-- 将这里改为你的数据集路径
+```
+
+例如：
+
+```yaml
+DATASET:
+  root: /home/user/data/SEE-600K/RoboticArm/
+```
+
+`options/SEE/SEENet_SEE.yaml` 中的默认基线配置如下：
+
+| 参数 | 数值 | 说明 |
+| --- | --- | --- |
+| `TRAIN_BATCH_SIZE` | 2 | 每张 GPU 的 batch size |
+| `VAL_BATCH_SIZE` | 2 | 验证 batch size |
+| `START_EPOCH` | 0 | 起始 epoch |
+| `END_EPOCH` | 20 | 训练总 epoch 数 |
+| `OPTIMIZER.NAME` | Adam | 优化器 |
+| `OPTIMIZER.LR` | 0.0001 | 学习率 |
+| `OPTIMIZER.LR_SCHEDULER` | cosine | 学习率调度器 |
+| `LOSS` | L1-Charbonnier + Gradient | 损失函数 |
+| `DATASET.crop_h` | 128 | 裁剪高度 |
+| `DATASET.crop_w` | 256 | 裁剪宽度 |
+| `MODEL.NAME` | SEENet | 模型结构 |
+| `MODEL.loop` | 10 | 稀疏编码器迭代次数 |
+| `MODEL.C1/C2` | 96 | 通道维度 |
+| `MIX_PRECISION` | true | 混合精度训练 |
+
+---
+
+## 5. 训练 SEE-Net
+
+运行基线训练命令：
+
+```bash
+export PYTHONPATH="./":$PYTHONPATH
+
+python see/main.py \
+  --yaml_file="options/SEE/SEENet_SEE.yaml" \
+  --log_dir="./logs/SEE/SEENet_SEE/" \
+  --alsologtostderr=True
+```
+
+也可以启动提供的脚本：
+
+```bash
+sh options/SEE/SEENet_SEE.sh
+```
+
+多 GPU 训练时，先设置可见 GPU 编号，再运行相同命令：
+
+```bash
+export CUDA_VISIBLE_DEVICES="0,1"
+
+python see/main.py \
+  --yaml_file="options/SEE/SEENet_SEE.yaml" \
+  --log_dir="./logs/SEE/SEENet_SEE/" \
+  --alsologtostderr=True
+```
+
+代码会自动使用 `nn.DataParallel` 进行多 GPU 训练。
+
+### 5.1 使用 TensorBoard 监控训练
+
+```bash
+tensorboard --logdir=./logs/SEE/SEENet_SEE/ --port=6006 --bind_all
+```
+
+随后在浏览器中打开 `http://localhost:6006`。如果在远程服务器上运行，请使用 SSH 端口转发：
+
+```bash
+ssh -L 6006:localhost:6006 user@server_ip
+```
+
+### 5.2 从检查点恢复训练
+
+```bash
+python see/main.py \
+  --yaml_file="options/SEE/SEENet_SEE.yaml" \
+  --log_dir="./logs/SEE/SEENet_SEE/" \
+  --alsologtostderr=True \
+  --RESUME_PATH="./logs/SEE/SEENet_SEE/checkpoint.pth.tar" \
+  --RESUME_SET_EPOCH=True
+```
+
+---
+
+## 6. 评测或运行推理
+
+训练完成后，可使用训练好的检查点运行验证：
+
+```bash
+python see/main.py \
+  --yaml_file="options/SEE/SEENet_SEE.yaml" \
+  --log_dir="./logs/SEE/SEENet_SEE/vis/" \
+  --alsologtostderr=True \
+  --RESUME_PATH="./logs/SEE/SEENet_SEE/checkpoint.pth.tar" \
+  --TEST_ONLY=True \
+  --VISUALIZE=True \
+  --VAL_BATCH_SIZE=4
+```
+
+主要测试参数如下：
+
+| 参数 | 说明 |
+| --- | --- |
+| `--TEST_ONLY=True` | 跳过训练，只运行验证 |
+| `--VISUALIZE=True` | 在验证期间保存输出图像 |
+| `--RESUME_PATH=<path>` | 训练好检查点的路径 |
+| `--VAL_BATCH_SIZE=4` | 在显存允许时增大 batch size 以加快推理 |
+
+评测可视化文件夹时，运行：
+
+```bash
+python tools/2-eval-for-vis-folder/SEE_eval_for_model.py \
+    --root="/path/to/your/vis/folder" \
+    --log_dir="/path/to/your/log/dir" \
+    --alsologtostderr=True
+```
+
+使用显式 ground-truth 根目录进行评测时，运行：
+
+```bash
+python tools/2-eval-for-vis-folder/SEE_eval_for_model_with_gt_root.py \
+    --root="/path/to/your/eval/folder" \
+    --gt_root="/path/to/your/gt/root" \
+    --log_dir="/path/to/your/log/dir" \
+    --alsologtostderr=True
+```
+
+基线指标汇总见 [TEST_RESULTS.md](./TEST_RESULTS.md) 和 [TEST_MINI_RESULTS.md](./TEST_MINI_RESULTS.md)。
+
+---
+
+## 7. 使用曝光提示进行亮度调整
+
+SEE-Net 通过曝光提示 **B** 支持连续亮度控制：
+
+- **B ≈ 0.5**：正常曝光，也是典型工作范围；
+- **B > 0.5**：输出更亮；
+- **B < 0.5**：输出更暗。
+
+模型在解码阶段应用该提示：
+
+```python
+exposure_prompt = torch.ones(size=(B, 1, 1, 1)) * exposure_B
+exposure_prompt = exposure_prompt.to(images.device)
+exposure_normal_reconstructed = self._decoding(light_inr, exposure_prompt)
+```
+
+测试时，模型会生成三类输出：
+
+- **PRD**：使用目标曝光提示得到的预测结果；
+- **SLR**：使用输入均值进行的自监督重建；
+- **NLR**：使用固定 `B=0.4` 的标准光照重建。
+
+**B** 的极端取值主要用于分析和可视化，而不是作为目标输出。该框架面向亮度调整，而不是完整 HDR 重建。
+
+---
+
+## 8. 常见问题
+
+### 需要多少 GPU 显存？
+
+基线 SEENet 模型约有 **1.9M 参数**。在 batch size 为 2、裁剪尺寸为 128×256 时，约需要 **6-8 GB** GPU 显存。可根据硬件情况调整 `TRAIN_BATCH_SIZE` 和裁剪尺寸。
+
+### 可以使用外部数据吗？
+
+可以。允许使用外部训练数据、预训练模型和合成数据，但必须在最终技术报告中**明确说明**。
+
+### 训练需要多长时间？
+
+使用单张 A100 GPU 时，20 个 epoch 的基线训练大约需要 **10-15 小时**。训练时间会随 GPU 型号而变化。
+
+### 为什么 TensorBoard 是空的？
+
+请检查以下内容：
+
+1. `--logdir` 指向包含 `events.out.tfevents.*` 文件的目录。
+2. 训练已经开始，并至少记录了一个 epoch；可检查配置中的 `LOG_INTERVAL`。
+3. 如果使用远程服务器，请确认 SSH 端口转发配置正确。
+
+---
+
+## 9. 引用
+
+如果使用 SEE-600K 数据集或 SEE-Net，请引用：
+
+```bibtex
+@article{lu2025SEE,
+  title={SEE: See Everything Every Time - Adaptive Brightness Adjustment for Broad Light Range Images via Events},
+  author={Yunfan Lu, Xiaogang Xu, Hao Lu, Yanlin Qian, Pengteng Li, Huizai Yao, Bin Yang, Junyi Li, Qianyi Cai, Weiyu Guo, Hui Xiong},
+  year={2025},
+}
+```
+
+---
+
+## 10. 联系方式
+
+- **Yunfan Lu**: <ylu066@connect.hkust-gz.edu.cn>
+- **GitHub**: [yunfanLu](https://github.com/yunfanLu)


### PR DESCRIPTION
### Motivation
- Consolidate and clarify repository documentation so each Markdown file has a single responsibility (project overview, full tutorial, CodaBench submission guide, and competition page text) and avoid duplicated content across files.
- Provide Chinese counterparts for all produced English docs so participants and users can read natural-language translations that match the English content exactly.
- Preserve all existing dataset, pretrained-model URLs, command snippets, and links while removing redundant sections from multiple files.

### Description
- Rewrote `README.md` into a concise project overview and added the matching Chinese file `README_ZH.md` with equivalent content and links.
- Moved full usage and operational instructions into `docs/TUTORIAL.md` and added `docs/TUTORIAL_ZH.md` as the Chinese translation; the tutorial contains environment setup, dataset preparation, training, evaluation, inference, exposure-prompt usage, FAQ, citation, and contact info.
- Refactored the submission-specific material into `docs/CODABENCH_SUBMISSION_GUIDE.md` and `docs/CODABENCH_SUBMISSION_GUIDE_ZH.md`, and created concise standalone pages for the competition: `CODABENCH_README.md` and `CODABENCH_README_ZH.md` (visual overview and quick start for participants).
- Removed duplicated evaluation instructions from `docs/TEST_RESULTS.md` and `docs/TEST_MINI_RESULTS.md` and replaced them with links to the tutorial; preserved all original dataset/model URLs and command snippets exactly.

### Testing
- Ran `git diff --check` to ensure no whitespace or malformed diff issues, which passed successfully.
- Executed a Python validation script that verified the expected Markdown files exist, end with a trailing newline, and do not contain malformed fenced-code markers; this validation succeeded for the set of updated/added files (`README.md`, `README_ZH.md`, `docs/TUTORIAL.md`, `docs/TUTORIAL_ZH.md`, `docs/CODABENCH_SUBMISSION_GUIDE.md`, `docs/CODABENCH_SUBMISSION_GUIDE_ZH.md`, `CODABENCH_README.md`, `CODABENCH_README_ZH.md`, `docs/TEST_RESULTS.md`, `docs/TEST_MINI_RESULTS.md`).
- Performed spot checks to confirm that all original dataset and pretrained-model links, command examples (e.g. `hf download`, `pip install -r requirements.txt`, `python see/main.py`, `zip -r submission.zip`), and image references were preserved in the rewritten files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae4c39bf88326a53ff1fd2a86f287)